### PR TITLE
[CNT-35256]magento-2 create order response header key base on afterSave event

### DIFF
--- a/Constants.php
+++ b/Constants.php
@@ -33,7 +33,7 @@ class Constants
 
     public const WEBHOOK_RESOURCE_CREDITMEMOS = 'creditmemos';
 
-    public const AFTERSHIP_TIKTOK_SHOP_VERSION = '1.0.19';
+    public const AFTERSHIP_TIKTOK_SHOP_VERSION = '1.0.21';
 
     public const WEBHOOK_CONFIG_SCOPE_PATH = 'aftership/webhooks/webhooks';
 

--- a/Plugin/CreateReservationsAfterPlaceOrder.php
+++ b/Plugin/CreateReservationsAfterPlaceOrder.php
@@ -111,15 +111,13 @@ class CreateReservationsAfterPlaceOrder
             $actions = explode(',', $actions);
             if (in_array('decrement', $actions)) {
                 if ($this->isMSIEnabled()) {
-                    $this->sendSalesEvent($order);
-
-                    $result['status'] = 'success';
                     $result['method'] = 'sendSalesEvent';
-                } else {
-                    $this->updateStockItemQty($order);
-
+                    $this->sendSalesEvent($order);
                     $result['status'] = 'success';
+                } else {
                     $result['method'] = 'updateStockItemQty';
+                    $this->updateStockItemQty($order);
+                    $result['status'] = 'success';
                 }
             }
         } catch (\Exception $e) {
@@ -127,8 +125,9 @@ class CreateReservationsAfterPlaceOrder
             $result['message'] = $e->getMessage();
             $this->logger->error(
                 sprintf(
-                    '[AfterShip TikTokShop] Failed to create reservation for order %s, %s',
+                    '[AfterShip TikTokShop] Failed to create reservation for order %s using method: %s, error message: %s',
                     $order->getIncrementId(),
+                    $result['method'] ?? 'unknown',
                     $e->getMessage()
                 )
             );

--- a/Plugin/CreateReservationsAfterPlaceOrder.php
+++ b/Plugin/CreateReservationsAfterPlaceOrder.php
@@ -1,5 +1,12 @@
 <?php
-
+/**
+ * TikTokShop CreateReservationsAfterPlaceOrder
+ *
+ * @author    AfterShip <support@aftership.com>
+ * @copyright 2023 AfterShip
+ * @license   MIT http://opensource.org/licenses/MIT
+ * @link      https://aftership.com
+ */
 namespace AfterShip\TikTokShop\Plugin;
 
 use AfterShip\TikTokShop\Constants;
@@ -250,12 +257,6 @@ class CreateReservationsAfterPlaceOrder
                 'X-AS-Inventory-Reservation-Result',
                 json_encode($result),
                 true
-            );
-            $this->logger->info(
-                sprintf(
-                    '[AfterShip TikTokShop] response header X-AS-Inventory-Reservation-Result: %s',
-                    json_encode($result)
-                )
             );
             // 确保响应被发送
             $response->sendResponse();

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "aftership/tiktok-shop",
     "description": "Aftership TikTok Shop extension for Magento 2. Allows connect with TikTok Shop and more.",
     "type": "magento2-module",
-    "version": "1.0.20",
+    "version": "1.0.21",
     "minimum-stability": "stable",
     "license": "MIT",
     "keywords": ["aftership", "magento", "magento2", "magento-2", "tiktok", "shopping", "shop", "feed"],


### PR DESCRIPTION
背景：
https://aftership.atlassian.net/browse/CNT-35256

变更：
Magento Feed 插件 create order - afterSave API 新增 header key 信息返回，用于 workflow task 服务 magento create order 流程中获取该 header 标识进行判断，记录日志，便于后期问题追踪

X-AS-Inventory-Reservation-Result
{
    "order_id": "TT-ORDER-001-1",
    "status": "success",
    "method": "sendSalesEvent",
    "message": ""
}

或
{
    "order_id": "TT-ORDER-008-01",
    "status": "failed",
    "method": "sendSalesEvent",
    "message": "The requested qty is not available"
}